### PR TITLE
repositioned shareable button

### DIFF
--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -13,9 +13,8 @@ import {
     CompatibilityScore,
     UserProfile,
     AnalysisDetails,
-    ResultsActions
-} from "@/lib/components/results"
-import ImageGenerator from "@/components/results/ImageGenerator"
+    ResultsActions,
+} from "@/lib/components/results";
 
 interface ResultsData {
     userA: DeveloperAnalysis
@@ -67,17 +66,13 @@ function ResultsContent() {
             <CompatibilityScore compatibility={compatibility} />
 
             {/* Detailed Analysis - Third */}
-            <AnalysisDetails compatibility={compatibility} />
+            <AnalysisDetails
+                userA={analysisA}
+                userB={analysisB}
+                compatibility={compatibility}
+            />
 
-            {/* Image Generation */}
-            <div className="mt-8 flex flex-row justify-center items-center gap-6">
-                <ImageGenerator 
-                    userA={analysisA} 
-                    userB={analysisB} 
-                    compatibility={compatibility} 
-                />
-                <ResultsActions />
-            </div>
+            <ResultsActions />
         </ResultsLayout>
     )
 }

--- a/components/results/AnalysisDetails.tsx
+++ b/components/results/AnalysisDetails.tsx
@@ -1,11 +1,23 @@
-import { CheckCircle, AlertTriangle, Lightbulb, BrainCircuit } from "lucide-react"
-import { CompatibilityAnalysis } from "@/lib/types"
+import {
+    CheckCircle,
+    AlertTriangle,
+    Lightbulb,
+    BrainCircuit,
+} from "lucide-react";
+import { DeveloperAnalysis, CompatibilityAnalysis } from "@/lib/types";
+import ImageGenerator from "@/components/results/ImageGenerator";
 
 interface AnalysisDetailsProps {
-    compatibility: CompatibilityAnalysis
+    userA: DeveloperAnalysis;
+    userB: DeveloperAnalysis;
+    compatibility: CompatibilityAnalysis;
 }
 
-export default function AnalysisDetails({ compatibility }: AnalysisDetailsProps) {
+export default function AnalysisDetails({
+    userA,
+    userB,
+    compatibility,
+}: AnalysisDetailsProps) {
     return (
         <>
             {/* Custom Focus Insights */}
@@ -25,6 +37,14 @@ export default function AnalysisDetails({ compatibility }: AnalysisDetailsProps)
                     </ul>
                 </div>
             )}
+
+            <div className="my-8 flex justify-center">
+                <ImageGenerator
+                    userA={userA}
+                    userB={userB}
+                    compatibility={compatibility}
+                />
+            </div>
 
             {/* Detailed Analysis */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">


### PR DESCRIPTION
This pull request refactors the `ImageGenerator` component integration within the results page and the `AnalysisDetails` component to improve code organization and maintainability. The most significant changes include moving the `ImageGenerator` component from the results page to the `AnalysisDetails` component and updating the props for better encapsulation.

### Refactoring and Component Reorganization:

* `app/results/page.tsx`:
  - Removed the `ImageGenerator` component from the results page and its associated wrapper `div`. The `ImageGenerator` logic is now handled within the `AnalysisDetails` component.
  - Updated the `AnalysisDetails` component invocation to include new props: `userA` and `userB`.

* `components/results/AnalysisDetails.tsx`:
  - Added the `ImageGenerator` component directly within the `AnalysisDetails` component, encapsulating its functionality. This improves modularity and reduces coupling with the results page.
  - Updated the `AnalysisDetails` props to include `userA` and `userB` for passing required data to `ImageGenerator`.

### Code Style Improvements:

* Reformatted imports in both `app/results/page.tsx` and `components/results/AnalysisDetails.tsx` for consistency and readability. [[1]](diffhunk://#diff-ab758472511e3898e9f8aad0b3e0991526710ac333d92d486ac10c5c071868a0L16-R17) [[2]](diffhunk://#diff-e4deae144a87e432bc247c40b55f8305da166180ae2c4169f5b3691d2a909edcL1-R20)